### PR TITLE
Fix empty subnets

### DIFF
--- a/aws-vpc-single-nat.tf
+++ b/aws-vpc-single-nat.tf
@@ -19,6 +19,15 @@ variable "public_subnets" {
   ]
 }
 
+variable "public_subnet_names" {
+  type = "list"
+
+  default = [
+      "DMZ",
+      "Load-balancers"
+  ]
+}
+
 variable "private_subnets" {
   type = "list"
 
@@ -54,6 +63,7 @@ module "backbone" {
   region          = "${var.region}"
   vpc_cidr        = "${var.vpc_cidr}"
   public_subnets  = "${var.public_subnets}"
+  public_subnet_names  = "${var.public_subnet_names}"
   private_subnets = "${var.private_subnets}"
   tags            = "${var.tags}"
 }

--- a/aws-vpc-single-nat.tf
+++ b/aws-vpc-single-nat.tf
@@ -14,14 +14,8 @@ variable "public_subnets" {
   type = "list"
 
   default = [
-    {
-      name      = "Public1"
-      base_cidr = "10.0.0.0/20"
-    },
-    {
-      name      = "Public2"
-      base_cidr = "10.0.32.0/20"
-    },
+      "10.0.0.0/20",
+      "10.0.32.0/20"
   ]
 }
 
@@ -29,14 +23,8 @@ variable "private_subnets" {
   type = "list"
 
   default = [
-    {
-      name      = "Private1"
-      base_cidr = "10.0.64.0/20"
-    },
-    {
-      name      = "Private2"
-      base_cidr = "10.0.96.0/20"
-    },
+      "10.0.64.0/20",
+      "10.0.96.0/20"
   ]
 }
 

--- a/aws/backbone/subnets.tf
+++ b/aws/backbone/subnets.tf
@@ -14,7 +14,7 @@ resource "aws_subnet" "public" {
   vpc_id = "${aws_vpc.main.id}"
 
   # XXX TODO - Explain this block
-  cidr_block = "${cidrsubnet(lookup(var.public_subnets[ count.index / length(module.helper.azs) ],"base_cidr"),
+  cidr_block = "${cidrsubnet(element(var.public_subnets,count.index / length(module.helper.azs) ),
                                   ceil(log(length(module.helper.azs),2)),
                                   count.index % length(module.helper.azs)
                                 )}"
@@ -30,7 +30,7 @@ resource "aws_subnet" "private" {
   vpc_id = "${aws_vpc.main.id}"
 
   # XXX TODO - Explain this block
-  cidr_block = "${cidrsubnet(lookup(var.private_subnets[ count.index / length(module.helper.azs) ],"base_cidr"),
+  cidr_block = "${cidrsubnet(element(var.private_subnets, count.index / length(module.helper.azs) ),
                                   ceil(log(length(module.helper.azs),2)),
                                   count.index % length(module.helper.azs)
                                 )}"

--- a/aws/backbone/subnets.tf
+++ b/aws/backbone/subnets.tf
@@ -22,7 +22,10 @@ resource "aws_subnet" "public" {
   availability_zone       = "${module.helper.azs[count.index % length(module.helper.azs)]}"
   map_public_ip_on_launch = "true"
 
-  tags = "${var.tags}"
+  tags = "${merge(var.tags,
+                  map("Name", length(var.public_subnet_names)==0 ? 
+                                "public-${count.index / length(module.helper.azs)}-${module.helper.azs[count.index % length(module.helper.azs)]}" :
+                                "${element(concat(var.public_subnet_names,list("")),count.index / length(module.helper.azs))}-${module.helper.azs[count.index % length(module.helper.azs)]}")) }"
 }
 
 resource "aws_subnet" "private" {
@@ -37,5 +40,8 @@ resource "aws_subnet" "private" {
 
   availability_zone = "${module.helper.azs[count.index % length(module.helper.azs)]}"
 
-  tags = "${var.tags}"
+  tags = "${merge(var.tags,
+                  map("Name", length(var.private_subnet_names)==0 ? 
+                                "private-${count.index / length(module.helper.azs)}-${module.helper.azs[count.index % length(module.helper.azs)]}" :
+                                "${element(concat(var.private_subnet_names,list("")),count.index / length(module.helper.azs))}-${module.helper.azs[count.index % length(module.helper.azs)]}")) }"
 }

--- a/aws/backbone/variables.tf
+++ b/aws/backbone/variables.tf
@@ -14,7 +14,17 @@ variable "private_subnets" {
   default = []
 }
 
+variable "private_subnet_names" {
+  type    = "list"
+  default = []
+}
+
 variable "public_subnets" {
+  type    = "list"
+  default = []
+}
+
+variable "public_subnet_names" {
   type    = "list"
   default = []
 }

--- a/aws/helper/outputs.tf
+++ b/aws/helper/outputs.tf
@@ -1,3 +1,3 @@
 output "azs" {
-  value = "${slice(data.aws_availability_zones.available.names, 0, (var.azs_count == 0 ? length(data.aws_availability_zones.available.names) : min(var.azs_count,length(data.aws_availability_zones.available.names))) - 1)}"
+  value = "${slice(data.aws_availability_zones.available.names, 0, (var.azs_count == 0 ? length(data.aws_availability_zones.available.names) : min(var.azs_count,length(data.aws_availability_zones.available.names))) )}"
 }


### PR DESCRIPTION
Here is my proposition to fix the issue with empty lists for public or private subnets
Instead of using a list of maps with both CIDR and name for the subnets I only use a list of CIDR

As an option you can add a list of subnet names to set up tags. If you don't the default behavior is to name subnets public-<az> or private-<az>