### PR TITLE
Feature roles datasources

### DIFF
--- a/aws-vpc-single-nat.tf
+++ b/aws-vpc-single-nat.tf
@@ -63,7 +63,7 @@ module "backbone" {
   region                = "${var.region}"
   vpc_cidr              = "${var.vpc_cidr}"
   public_subnet_blocks  = "${var.public_subnet_blocks}"
-  public_subnet_names   = "${var.public_subnet_names}"
+  public_subnet_roles   = "${var.public_subnet_roles}"
   private_subnet_blocks = "${var.private_subnet_blocks}"
   tags                  = "${var.tags}"
 }

--- a/aws/backbone/README.md
+++ b/aws/backbone/README.md
@@ -21,10 +21,10 @@ This module sets up an AWS backbone base infrastructure.
   variable and `azs_count`.
   - default: none
 
-- `private_subnet_names` (list)
+- `private_subnet_roles` (list)
 
-  List of private subnet names (matching `private_subnet_blocks` ordering).
-  - default: private-${count.index}-${az}
+  List of private subnet roles (matching `private_subnet_blocks` ordering).
+  - default: private-${count.index}
 
 - `public_subnet_blocks` (list)
 
@@ -32,10 +32,10 @@ This module sets up an AWS backbone base infrastructure.
   variable and `azs_count`.
   - default: none
 
-- `public_subnet_names` (list)
+- `public_subnet_roles` (list)
 
-  List of public subnet names (matching `public_subnet_blocks` ordering).
-  - default: public-${count.index}-${az}
+  List of public subnet roles (matching `public_subnet_blocks` ordering).
+  - default: public-${count.index}
 
 - `region` (string)
 

--- a/aws/backbone/subnets.tf
+++ b/aws/backbone/subnets.tf
@@ -24,9 +24,12 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = "true"
 
   tags = "${merge(var.tags,
-                  map("Name", length(var.public_subnet_names)==0 ? 
+                  map("Role", length(var.public_subnet_roles)==0 ?
+                                "public-${count.index / length(module.helper.azs)}" :
+                                element(concat(var.public_subnet_roles,list("")),count.index / length(module.helper.azs))),
+                  map("Name", length(var.public_subnet_roles)==0 ?
                                 "public-${count.index / length(module.helper.azs)}-${module.helper.azs[count.index % length(module.helper.azs)]}" :
-                                "${element(concat(var.public_subnet_names,list("")),count.index / length(module.helper.azs))}-${module.helper.azs[count.index % length(module.helper.azs)]}")) }"
+                                "${element(concat(var.public_subnet_roles,list("")),count.index / length(module.helper.azs))}-${module.helper.azs[count.index % length(module.helper.azs)]}")) }"
 }
 
 resource "aws_subnet" "private" {
@@ -42,7 +45,10 @@ resource "aws_subnet" "private" {
   availability_zone = "${module.helper.azs[count.index % length(module.helper.azs)]}"
 
   tags = "${merge(var.tags,
-                  map("Name", length(var.private_subnet_names)==0 ? 
+                  map("Role", length(var.private_subnet_roles)==0 ?
+                                "private-${count.index / length(module.helper.azs)}" :
+                                element(concat(var.private_subnet_roles,list("")),count.index / length(module.helper.azs))),
+                  map("Name", length(var.private_subnet_roles)==0 ?
                                 "private-${count.index / length(module.helper.azs)}-${module.helper.azs[count.index % length(module.helper.azs)]}" :
-                                "${element(concat(var.private_subnet_names,list("")),count.index / length(module.helper.azs))}-${module.helper.azs[count.index % length(module.helper.azs)]}")) }"
+                                "${element(concat(var.private_subnet_roles,list("")),count.index / length(module.helper.azs))}-${module.helper.azs[count.index % length(module.helper.azs)]}")) }"
 }

--- a/aws/backbone/subnets.tf
+++ b/aws/backbone/subnets.tf
@@ -7,6 +7,7 @@ resource "aws_vpc" "main" {
 module "helper" {
   source    = "github.com/d2si-oss/terraform-modules//aws/helper"
   azs_count = "${var.azs_count}"
+  region    = "${var.region}"
 }
 
 resource "aws_subnet" "public" {

--- a/aws/backbone/variables.tf
+++ b/aws/backbone/variables.tf
@@ -14,7 +14,7 @@ variable "private_subnet_blocks" {
   default = []
 }
 
-variable "private_subnet_names" {
+variable "private_subnet_roles" {
   type    = "list"
   default = []
 }
@@ -24,7 +24,7 @@ variable "public_subnet_blocks" {
   default = []
 }
 
-variable "public_subnet_names" {
+variable "public_subnet_roles" {
   type    = "list"
   default = []
 }

--- a/aws/helper/variables.tf
+++ b/aws/helper/variables.tf
@@ -1,3 +1,5 @@
+variable "region" {}
+
 variable "azs_count" {
   description = "Number of Availability Zones; 0 = use all AZs; maxed out at region's AZs"
   default     = 0


### PR DESCRIPTION
- Use "roles" instead of "names" to describe subnets
- Use data sources to retrieve data about created VPC based on tags
- Add provider with region everywhere to avoid region discrepancies between data sources and resources
