### PR TITLE
Option to manage VGW

### DIFF
--- a/aws/backbone/README.md
+++ b/aws/backbone/README.md
@@ -52,6 +52,18 @@ This module sets up an AWS backbone base infrastructure.
   VPC CIDR block.
   - default: none
 
+- `vgw_id` (string)
+
+  Id ot the virtual gateway to attach to the VPC (`""`: no VGW)
+  - default: ""
+
+- `vgw_prop` (string)
+
+  Propagation of routes configured on the VGW, can be `none` (no propagation),
+  `all` (propagate to all subnets), `private` (propagate only for private subnets)
+  - default: "all"
+
+
 ## Outputs
 
 - `private_subnets_cidr` - CIDR of private subnets

--- a/aws/backbone/README.md
+++ b/aws/backbone/README.md
@@ -54,12 +54,12 @@ This module sets up an AWS backbone base infrastructure.
 
 - `vgw_id` (string)
 
-  Id ot the virtual gateway to attach to the VPC (`""`: no VGW)
+  Id of the Virtual Gateway (VGW) to attach to the VPC (No attachment if empty)
   - default: ""
 
 - `vgw_prop` (string)
 
-  Propagation of routes configured on the VGW, can be `none` (no propagation),
+  Propagation of routes configured on the Virtual Gateway (VGW), can be `none` (no propagation),
   `all` (propagate to all subnets), `private` (propagate only for private subnets)
   - default: "all"
 

--- a/aws/backbone/route_tables.tf
+++ b/aws/backbone/route_tables.tf
@@ -32,7 +32,7 @@ resource "aws_route_table" "public" {
 resource "aws_route" "igw" {
   route_table_id         = "${aws_route_table.public.id}"
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id = "${aws_internet_gateway.public.id}"
+  gateway_id             = "${aws_internet_gateway.public.id}"
 }
 
 resource "aws_vpn_gateway_route_propagation" "public" {

--- a/aws/backbone/route_tables.tf
+++ b/aws/backbone/route_tables.tf
@@ -27,11 +27,12 @@ resource "aws_route_table" "public" {
   count  = "${length(var.public_subnet_blocks) == 0 ? 0 : 1}"
   tags   = "${merge(var.tags,local.public_name)}"
   vpc_id = "${aws_vpc.main.id}"
+}
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.public.id}"
-  }
+resource "aws_route" "igw" {
+  route_table_id         = "${aws_route_table.public.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id = "${aws_internet_gateway.public.id}"
 }
 
 resource "aws_vpn_gateway_route_propagation" "public" {

--- a/aws/backbone/route_tables.tf
+++ b/aws/backbone/route_tables.tf
@@ -2,20 +2,43 @@
 # Public Route Table
 #
 
+locals {
+  public_name = {
+    Name = "${lookup(var.tags,"Name","Route Table")} Public"
+  }
+
+  private_name = {
+    Name = "${lookup(var.tags,"Name","Route Table")} Private"
+  }
+}
+
 resource "aws_internet_gateway" "public" {
   vpc_id = "${aws_vpc.main.id}"
   tags   = "${var.tags}"
 }
 
+resource "aws_vpn_gateway_attachment" "vgw" {
+  count          = "${var.vgw_id == "" ? 0 : 1}"
+  vpc_id         = "${aws_vpc.main.id}"
+  vpn_gateway_id = "${var.vgw_id}"
+}
+
 resource "aws_route_table" "public" {
   count  = "${length(var.public_subnet_blocks) == 0 ? 0 : 1}"
-  tags   = "${var.tags}"
+  tags   = "${merge(var.tags,local.public_name)}"
   vpc_id = "${aws_vpc.main.id}"
 
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = "${aws_internet_gateway.public.id}"
   }
+}
+
+resource "aws_vpn_gateway_route_propagation" "public" {
+  count          = "${length(var.public_subnet_blocks) > 0 && var.vgw_id != "" && var.vgw_prop == "all" ? 1 : 0}"
+  vpn_gateway_id = "${var.vgw_id}"
+  route_table_id = "${element(aws_route_table.public.*.id,count.index)}"
+  depends_on     = ["aws_vpn_gateway_attachment.vgw"]
 }
 
 resource "aws_route_table_association" "public" {
@@ -31,8 +54,15 @@ resource "aws_route_table_association" "public" {
 resource "aws_route_table" "private_standalone" {
   count = "${length(var.private_subnet_blocks) != 0 && var.nat_type == "none" ? 1 : 0}"
 
-  tags   = "${var.tags}"
+  tags   = "${merge(var.tags,local.private_name)}"
   vpc_id = "${aws_vpc.main.id}"
+}
+
+resource "aws_vpn_gateway_route_propagation" "private_standalone" {
+  count          = "${length(var.private_subnet_blocks) != 0 && var.nat_type == "none" && var.vgw_id != "" && var.vgw_prop != "none" ? 1 : 0}"
+  vpn_gateway_id = "${var.vgw_id}"
+  route_table_id = "${element(aws_route_table.private_standalone.*.id,count.index)}"
+  depends_on     = ["aws_vpn_gateway_attachment.vgw"]
 }
 
 #
@@ -42,8 +72,15 @@ resource "aws_route_table" "private_standalone" {
 resource "aws_route_table" "private_single" {
   count = "${length(var.private_subnet_blocks) != 0 && var.nat_type == "single" ? 1 : 0}"
 
-  tags   = "${var.tags}"
+  tags   = "${merge(var.tags,local.private_name)}"
   vpc_id = "${aws_vpc.main.id}"
+}
+
+resource "aws_vpn_gateway_route_propagation" "private_single" {
+  count          = "${length(var.private_subnet_blocks) != 0 && var.nat_type == "single" && var.vgw_id != "" && var.vgw_prop != "none" ? 1 : 0}"
+  vpn_gateway_id = "${var.vgw_id}"
+  route_table_id = "${element(aws_route_table.private_single.*.id,count.index)}"
+  depends_on     = ["aws_vpn_gateway_attachment.vgw"]
 }
 
 resource "aws_eip" "private_single" {
@@ -86,8 +123,15 @@ resource "aws_route_table_association" "private_single" {
 resource "aws_route_table" "private_multi" {
   count = "${length(var.private_subnet_blocks) != 0 && var.nat_type == "multi" ? length(local.azs) : 0}"
 
-  tags   = "${var.tags}"
+  tags   = "${merge(var.tags,local.private_name)}"
   vpc_id = "${aws_vpc.main.id}"
+}
+
+resource "aws_vpn_gateway_route_propagation" "private_multi" {
+  count          = "${length(var.private_subnet_blocks) != 0 && var.nat_type == "multi" && var.vgw_id != "" && var.vgw_prop != "none" ? length(local.azs) : 0}"
+  vpn_gateway_id = "${var.vgw_id}"
+  route_table_id = "${element(aws_route_table.private_multi.*.id,count.index)}"
+  depends_on     = ["aws_vpn_gateway_attachment.vgw"]
 }
 
 resource "aws_eip" "private_multi" {

--- a/aws/backbone/variables.tf
+++ b/aws/backbone/variables.tf
@@ -41,3 +41,15 @@ variable "tags" {
 variable "vpc_cidr" {
   description = "VPC CIDR block"
 }
+
+variable "vgw_id" {
+  description = "ID of a VGW to attach to the VPC. No attachment if empty"
+  type        = "string"
+  default     = ""
+}
+
+variable "vgw_prop" {
+  description = "Propagate VGW route; all= public and private subnets; private= private subnets only; none= no propagation"
+  type        = "string"
+  default     = "all"
+}

--- a/aws/backbone/variables.tf
+++ b/aws/backbone/variables.tf
@@ -43,13 +43,13 @@ variable "vpc_cidr" {
 }
 
 variable "vgw_id" {
-  description = "ID of a VGW to attach to the VPC. No attachment if empty"
+  description = "ID of a Virtual Gateway (VGW) to attach to the VPC. No attachment if empty"
   type        = "string"
   default     = ""
 }
 
 variable "vgw_prop" {
-  description = "Propagate VGW route; all= public and private subnets; private= private subnets only; none= no propagation"
-  type        = "string"
+  description = "Propagate Virtual Gateway (VGW) routes; all= public and private subnets; private= private subnets only; none= no propagation"
+type        = "string"
   default     = "all"
 }

--- a/aws/backbone/variables.tf
+++ b/aws/backbone/variables.tf
@@ -50,6 +50,6 @@ variable "vgw_id" {
 
 variable "vgw_prop" {
   description = "Propagate Virtual Gateway (VGW) routes; all= public and private subnets; private= private subnets only; none= no propagation"
-type        = "string"
+  type        = "string"
   default     = "all"
 }


### PR DESCRIPTION
Add possibility to attach a VGW and configure route propagation

The VGW itself is not managed by terraform because of VPN/Directconnect lifecycles (destroying a VGW would mean destroying VPN connections and VIF, which is usually not wanted). The idea is to create and configure the VGW outside of this stack and to reference it (directly or using a datasource).

Two configuration options:

- vgw_id: id of the vgw to attach (default="" => no vgw)
- vgw_prop: configuration of route propagation (all, private or none, default=all)